### PR TITLE
Add *args and *kwargs to action command hook

### DIFF
--- a/octoprint_actioncommands/__init__.py
+++ b/octoprint_actioncommands/__init__.py
@@ -81,7 +81,7 @@ class ActionCommandsPlugin(octoprint.plugin.TemplatePlugin,
         )
     )
 
-    def hook_actioncommands(self, comm, line, command):
+    def hook_actioncommands(self, comm, line, command, *args, **kwargs):
         self._logger.info("Command received: 'action:%s'" % (command))
         
         if command == None:


### PR DESCRIPTION
This should have been included per the documentation, in OctoPrint 1.5.0 there was a new key word arg passed (`name`). This fixes this issue, and also makes it *future proof* to any more issues like this.